### PR TITLE
[feature/home_reselected]: fragment 전환 방식변경

### DIFF
--- a/app/src/main/java/com/teampophory/pophory/feature/home/HomeActivity.kt
+++ b/app/src/main/java/com/teampophory/pophory/feature/home/HomeActivity.kt
@@ -25,13 +25,6 @@ import kotlinx.coroutines.launch
 class HomeActivity : AppCompatActivity() {
     private val binding: ActivityHomeBinding by viewBinding(ActivityHomeBinding::inflate)
     private val viewModel by viewModels<HomeViewModel>()
-
-    private val fragmentMap = mapOf(
-        R.id.menu_store to StoreFragment(),
-        R.id.menu_my_page to MyPageFragment()
-    )
-
-
     private val addPhotoResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         if (it.resultCode == RESULT_OK) {
             val albumItem = it.data?.getParcelableExtra(AddPhotoActivity.EXTRA_ALBUM_ITEM) as? AlbumItem
@@ -55,19 +48,21 @@ class HomeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         setupBottomNavigationBar()
-
-        //init fragment setting
         initializeDefaultFragment(savedInstanceState)
-        binding.homeBottomNav.selectedItemId = R.id.menu_store
     }
 
     private fun setupBottomNavigationBar() {
-
         binding.homeBottomNav.setOnItemSelectedListener { item ->
-            val selectedFragment = fragmentMap[item.itemId]
+            val selectedFragment = when (item.itemId) {
+                R.id.menu_store -> StoreFragment()
+                R.id.menu_my_page -> MyPageFragment()
+                else -> null
+            }
             selectedFragment?.let { changeFragment(it) }
             return@setOnItemSelectedListener selectedFragment != null
         }
+
+        binding.homeBottomNav.setOnItemReselectedListener { }
 
         binding.bottomNavFav.setOnClickListener {
             imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
@@ -83,12 +78,7 @@ class HomeActivity : AppCompatActivity() {
 
     private fun changeFragment(fragment: Fragment) {
         supportFragmentManager.commit {
-            supportFragmentManager.fragments.forEach { hide(it) } // 모든 Fragment를 숨깁니다.
-            if (!fragment.isAdded) {
-                add(R.id.home_fcv, fragment)
-            } else {
-                show(fragment) // 선택한 Fragment만 보여줍니다.
-            }
+            replace(R.id.home_fcv, fragment)
         }
     }
 

--- a/app/src/main/java/com/teampophory/pophory/feature/home/HomeActivity.kt
+++ b/app/src/main/java/com/teampophory/pophory/feature/home/HomeActivity.kt
@@ -25,6 +25,13 @@ import kotlinx.coroutines.launch
 class HomeActivity : AppCompatActivity() {
     private val binding: ActivityHomeBinding by viewBinding(ActivityHomeBinding::inflate)
     private val viewModel by viewModels<HomeViewModel>()
+
+    private val fragmentMap = mapOf(
+        R.id.menu_store to StoreFragment(),
+        R.id.menu_my_page to MyPageFragment()
+    )
+
+
     private val addPhotoResultLauncher = registerForActivityResult(ActivityResultContracts.StartActivityForResult()) {
         if (it.resultCode == RESULT_OK) {
             val albumItem = it.data?.getParcelableExtra(AddPhotoActivity.EXTRA_ALBUM_ITEM) as? AlbumItem
@@ -48,19 +55,20 @@ class HomeActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(binding.root)
         setupBottomNavigationBar()
+
+        //init fragment setting
         initializeDefaultFragment(savedInstanceState)
+        binding.homeBottomNav.selectedItemId = R.id.menu_store
     }
 
     private fun setupBottomNavigationBar() {
+
         binding.homeBottomNav.setOnItemSelectedListener { item ->
-            val selectedFragment = when (item.itemId) {
-                R.id.menu_store -> StoreFragment()
-                R.id.menu_my_page -> MyPageFragment()
-                else -> null
-            }
+            val selectedFragment = fragmentMap[item.itemId]
             selectedFragment?.let { changeFragment(it) }
             return@setOnItemSelectedListener selectedFragment != null
         }
+
         binding.bottomNavFav.setOnClickListener {
             imagePicker.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
         }
@@ -75,7 +83,12 @@ class HomeActivity : AppCompatActivity() {
 
     private fun changeFragment(fragment: Fragment) {
         supportFragmentManager.commit {
-            replace(R.id.home_fcv, fragment)
+            supportFragmentManager.fragments.forEach { hide(it) } // 모든 Fragment를 숨깁니다.
+            if (!fragment.isAdded) {
+                add(R.id.home_fcv, fragment)
+            } else {
+                show(fragment) // 선택한 Fragment만 보여줍니다.
+            }
         }
     }
 


### PR DESCRIPTION
## 이슈 코드 

- close #136

## 📸 
[Screen_recording_20230711_201642.webm](https://github.com/TeamPophory/pophory-android/assets/52442547/39c24f19-d201-4bf2-a1a9-ac4af36cbf36)
스크린샷


## 🍀 관련 이슈
- 2차 스프린트 store와 mypage뷰를 고려하였을 때 replace() 대신 메모리를 유지하는 hide(), show() 방식을 채택하여도 성능에 큰 문제가 되지 않을 것으로 생각해 로직을 수정하였습니다.