### PR TITLE
replace buildDir to layout.buildDirectory

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,5 +31,5 @@ plugins {
 }
 
 tasks.register("clean", Delete::class) {
-    delete(rootProject.buildDir)
+    delete(rootProject.layout.buildDirectory)
 }


### PR DESCRIPTION
## 🍀 관련 이슈

- [Deprecate Project.getBuildDir()](https://github.com/gradle/gradle/issues/20210)