### PR TITLE
Remove DSL_SCOPE_VALIDATION annotations

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,5 @@
 import java.util.Properties
 
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("application")
     pophory("compose")

--- a/bottomnavigation/build.gradle.kts
+++ b/bottomnavigation/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
     pophory("compose")

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
     pophory("compose")

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
     alias(libs.plugins.sentry)

--- a/data/ad/build.gradle.kts
+++ b/data/ad/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
     alias(libs.plugins.sentry)

--- a/data/auth/build.gradle.kts
+++ b/data/auth/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
     alias(libs.plugins.sentry)

--- a/data/share/build.gradle.kts
+++ b/data/share/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
 }

--- a/domain/ad/build.gradle.kts
+++ b/domain/ad/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     `java-library`
     kotlin("jvm")

--- a/domain/auth/build.gradle.kts
+++ b/domain/auth/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     `java-library`
     kotlin("jvm")

--- a/domain/share/build.gradle.kts
+++ b/domain/share/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     `java-library`
     kotlin("jvm")

--- a/feature/auth/build.gradle.kts
+++ b/feature/auth/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
 }

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
 }

--- a/feature/setting/build.gradle.kts
+++ b/feature/setting/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
     pophory("compose")

--- a/feature/share/build.gradle.kts
+++ b/feature/share/build.gradle.kts
@@ -1,4 +1,3 @@
-@Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     pophory("feature")
 }


### PR DESCRIPTION
## 🍀 관련 이슈

- [KTIJ-19369](https://youtrack.jetbrains.com/issue/KTIJ-19369/False-positive-cant-be-called-in-this-context-by-implicit-receiver-with-plugins-in-Gradle-version-catalogs-as-a-TOML-file) Issue가 해결되어서 빌드 스크립트 파일에 어노테이션들을 삭제합니다.